### PR TITLE
Move package imports to module scope

### DIFF
--- a/rtl/datamover_engine.sv
+++ b/rtl/datamover_engine.sv
@@ -15,10 +15,11 @@
  * Authors:  Francesco Conti <f.conti@unibo.it>
  */
 
-import hwpe_stream_package::*;
-import hci_package::*;
 
-module datamover_engine #(
+module datamover_engine
+  import hwpe_stream_package::*;
+  import hci_package::*;
+#(
   parameter int unsigned FIFO_DEPTH = 4,
   parameter int unsigned BW_ALIGNED = 32
 ) (

--- a/rtl/datamover_streamer.sv
+++ b/rtl/datamover_streamer.sv
@@ -15,11 +15,12 @@
  * Authors:  Francesco Conti <f.conti@unibo.it>
  */
 
-import hwpe_stream_package::*;
-import hci_package::*;
-import datamover_package::*;
 
-module datamover_streamer #(
+module datamover_streamer
+  import hwpe_stream_package::*;
+  import hci_package::*;
+  import datamover_package::*;
+#(
   parameter int unsigned TCDM_FIFO_DEPTH = 2,
   parameter int unsigned BW = 32
 ) (

--- a/rtl/datamover_top.sv
+++ b/rtl/datamover_top.sv
@@ -15,11 +15,12 @@
  * Authors:  Francesco Conti <f.conti@unibo.it>
  */
 
-import hwpe_ctrl_package::*;
-import hci_package::*;
-import datamover_package::*;
 
-module datamover_top #(
+module datamover_top
+  import hwpe_ctrl_package::*;
+  import hci_package::*;
+  import datamover_package::*;
+ #(
   parameter int unsigned ID        = 10,
   parameter int unsigned BW        = 288,
   parameter int unsigned N_CORES   = 8,


### PR DESCRIPTION
Import packages into the compilation unit scope (meaning you put the import before the module declaration) is very bad practice. Depending on the tool (whether it puts every file into one single compilation unit or every file in its own compilation unit), it causes imported symbols with identical name to be overriden. E.g. this module's .* imports clash with the imports in the hwpe-mac-engine IP. Instead the import should happen after the module name declaration before the parameter list. That way, the import is scoped to the module. 